### PR TITLE
Updates for Mint 0.7.1

### DIFF
--- a/source/Wallet.mint
+++ b/source/Wallet.mint
@@ -71,9 +71,9 @@ module Sushi.Wallet {
     `
     (() => {
       try {
-        return new Ok(new Record(generateValidKeyPair()))
+        return #{Result::Ok(`new Record(generateValidKeyPair())`)}
       } catch (e) {
-        return new Err(#{KeyPair.Error::KeyPairGenerationError})
+        return #{Result::Err(KeyPair.Error::KeyPairGenerationError)}
       }
     })()
     `
@@ -95,9 +95,9 @@ module Sushi.Wallet {
           address: makeAddress(keyPair.hexPublicKey, #{networkPrefix})
         }
 
-        return new Ok(new Record(wallet))
+        return #{Result::Ok(`new Record(wallet)`)}
       } catch (e) {
-        return new Err(#{Wallet.Error::WalletGenerationError})
+        return #{Result::Err(Wallet.Error::WalletGenerationError)}
       }
     })()
     `
@@ -122,9 +122,9 @@ module Sushi.Wallet {
                salt: salt
         };
 
-        return new Ok(new Record(encryptedWallet))
+        return #{Result::Ok(`new Record(encryptedWallet)`)}
       } catch (e) {
-        return new Err(#{Wallet.Error::EncryptWalletError})
+        return #{Result::Err(Wallet.Error::EncryptWalletError)}
       }
     })()
     `
@@ -139,9 +139,9 @@ module Sushi.Wallet {
         var binaryCipherText = new Uint8Array(hexstring2ab(#{encryptedWallet}.ciphertext));
         var wallet = JSON.parse(bf.decode(binaryCipherText));
 
-        return new Ok(new Record(wallet))
+        return #{Result::Ok(`new Record(wallet)`)}
       } catch (e) {
-        return new Err(#{Wallet.Error::DecryptWalletError})
+        return #{Result::Err(Wallet.Error::DecryptWalletError)}
       }
     })()
     `
@@ -160,9 +160,9 @@ module Sushi.Wallet {
             wif: #{wif},
             address: address
         }
-        return new Ok(new Record(wallet))
+        return #{Result::Ok(`new Record(wallet)`)}
       } catch (e) {
-        return new Err(#{Wallet.Error::FromWifWalletError})
+        return  #{Result::Err(Wallet.Error::FromWifWalletError)}
       }
     })()
     `
@@ -185,9 +185,9 @@ module Sushi.Wallet {
             wif: #{wif},
             address: address
         }
-        return new Ok(new Record(wallet))
+        return #{Result::Ok(`new Record(wallet)`)}
       } catch (e) {
-        return new Err(#{Wallet.Error::FromWifWalletError})
+        return  #{Result::Err(Wallet.Error::FromWifWalletError)}
       }
     })()
     `
@@ -217,9 +217,9 @@ module Sushi.Wallet {
         var signed_transaction = #{transaction}
         signed_transaction.senders = signed_senders
 
-        return new Ok(new Record(signed_transaction))
+        return #{Result::Ok(`new Record(signed_transaction)`)}
       } catch (e) {
-        return new Err(#{Wallet.Error::SigningError})
+        return  #{Result::Err(Wallet.Error::SigningError)}
       }
     })()
     `
@@ -234,9 +234,9 @@ module Sushi.Wallet {
     `
     (() => {
       try {
-        return new Ok(verify(hexPublicKey, message, r, s));
+        return #{Result::Ok(`verify(hexPublicKey, message, r, s)`)}
       } catch (e) {
-        return new Err(#{Wallet.Error::SigningError})
+        return #{Result::Err(Wallet.Error::SigningError)}
       }
     })()
     `
@@ -257,9 +257,9 @@ module Sushi.Wallet {
         var checksum = decodedAddress.substring(decodedAddress.length - 6, decodedAddress.length);
         var res = checksum === hashedAddress.substring(0, 6);
 
-        return new Ok(res)
+        return #{Result::Ok(`res`)}
       } catch (e) {
-        return new Err(#{Wallet.Error::InvalidAddressError})
+        return #{Result::Err(Wallet.Error::InvalidAddressError)}
       }
     })()
     `
@@ -270,9 +270,9 @@ module Sushi.Wallet {
     (() => {
       try {
         var words = all_crypto.mnemonic.fromHex(#{hexPrivateKey}).toWords()
-        return new Ok(words)
+        return #{Result::Ok(`words`)}
       } catch (e) {
-        return new Err(#{Wallet.Error::MnemonicGenerationError})
+        return #{Result::Err(Wallet.Error::MnemonicGenerationError)}
       }
     })()
     `
@@ -283,9 +283,9 @@ module Sushi.Wallet {
     (() => {
       try {
         var pk = all_crypto.mnemonic.fromWords(#{words}).toHex()
-        return new Ok(pk)
+        return #{Result::Ok(`pk`)}
       } catch (e) {
-        return new Err(#{Wallet.Error::MnemonicGenerationError})
+        return #{Result::Err(Wallet.Error::MnemonicGenerationError)}
       }
     })()
     `

--- a/source/extra/Result.mint
+++ b/source/extra/Result.mint
@@ -1,9 +1,8 @@
 module Result.Extra {
   fun join (input : Result(x, Result(x, value))) : Result(x, value) {
-    if (Result.isOk(input)) {
-      `#{input}.value`
-    } else {
-      `new Err()`
+    case (input) {
+      Result::Ok value => value
+      Result::Err => input
     }
   }
 
@@ -11,7 +10,8 @@ module Result.Extra {
     func : Function(a, Result(x, b)),
     input : Result(x, a)
   ) : Result(x, b) {
-    Result.map(func, input)
+    input
+    |> Result.map(func)
     |> Result.Extra.join()
   }
 }


### PR DESCRIPTION
0.6.0 change `Maybe` and `Result` to be native enums instead of being defined by the runtime, not it just uses them, because of that change the value of `Maybe::Just` is stored in the `_0` property instead of `.value` this caused the `Result.Extra.join` function to return `undefined`, this was likely the source of the problem.

Other than fixing the problem above I've updated the way results are created using interpolation, however it would work with the old method as well but I think it might remove the `Ok` and `Err` classes from the compiled code at some time.